### PR TITLE
app.js: Fix a typo in a variable name

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -173,7 +173,7 @@ function getNonOverlappingGroups() {
 
 function loadFromCookies() {
     var loadedFromCookies = Cookies.getJSON("loadedCourseCodes")
-    if (loadFromCookies === undefined) {
+    if (loadedFromCookies === undefined) {
         return
     }
     loadedCourseCodes = loadedFromCookies


### PR DESCRIPTION
Change `loadFromCookies` to `loadedFromCookies` in the `loadFromCookies` function. Since the typo occurred in a test against `undefined` and since `loadFromCookies` is a valid identifier, the check never succeeded, which led to errors when using the app with no cookies set (e. g. when using it for the first time).