### PR TITLE
Hack: force the display of the timetable for the current semester

### DIFF
--- a/sisparse/sisparse.go
+++ b/sisparse/sisparse.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/net/html/atom"
 )
 
-const sisUrl = "https://is.cuni.cz/studium/predmety/index.php?do=predmet&kod=%s"
+const sisUrl = "https://is.cuni.cz/studium/predmety/index.php?do=predmet&kod=%s&skr=2018&sem=1"
 
 // Returns a two-dimensional array containing groups of events.
 // Each group is a slice of events which must be enrolled together,


### PR DESCRIPTION
Year and semester params were added to the request url in order to force SIS to serve us the timetable for the current semester.